### PR TITLE
Add ability to generate rollups

### DIFF
--- a/static-gen/src/aggregator.py
+++ b/static-gen/src/aggregator.py
@@ -14,11 +14,17 @@ class Aggregator:
     def rollUpDates(self):
         years = self.dir.getDateYears()
         print(years)
-        for year in years:
-            self._rollUpYear(year)
+        [self._rollUpYear(y) for y in years]
 
     def rollUpChannels(self):
-        pass
+        channelDirs = self.dir.getChannelDirs()
+        [self._rollUpChannel(ch) for ch in channelDirs]
+
+    def _rollUpChannel(self, channelDir):
+        print("Channel: {}".format(channelDir))
+        chDir = DataDir(channelDir)
+        yearDirs = chDir.getDateYears()
+        [self._rollUpYear(y) for y in yearDirs]
 
     # aggregattes a single year, which includes aggregating all
     # months that exist for that year
@@ -28,12 +34,11 @@ class Aggregator:
         allMonthFiles = self.dir.allJsonFiles(yearDir)
         yearData = self._combine(allMonthFiles)
         yearFile = str(yearDir) + '.json'
-        print("------------")
-        print(yearFile)
+        print("Year: {}".format(yearFile))
         fs_util.write_all_events(yearFile, yearData)
 
     def _rollUpMonth(self, monthDir):
-        print("------------\nAggregating {}".format(monthDir))
+        print("Rolling up {}".format(monthDir))
         files = self.dir.allJsonFiles(monthDir)
         monthData = self._combine(files)
         monthFile = str(monthDir) + ".json"

--- a/static-gen/src/aggregator.py
+++ b/static-gen/src/aggregator.py
@@ -1,0 +1,44 @@
+
+from data_dir import DataDir
+import fs_util
+import json
+from functools import reduce
+
+# does all the aggregation
+
+class Aggregator:
+
+    def __init__(self, dir):
+        self.dir = DataDir(dir)
+
+    def aggregateDates(self):
+        years = self.dir.getDateYears()
+        print(years)
+        for year in years:
+            self._aggregateYear(year)
+
+    # aggregattes a single year, which includes aggregating all
+    # months that exist for that year
+    def _aggregateYear(self, yearDir):
+        monthDirs = self.dir.getSubdirs(yearDir)
+        [self._aggregateMonth(m) for m in monthDirs]
+        allMonthFiles = self.dir.allJsonFiles(yearDir)
+        print(yearDir)
+        print(allMonthFiles)
+        yearData = self._combine(allMonthFiles)
+        yearFile = str(yearDir) + '.json'
+        fs_util.write_all_events(yearFile, yearData)
+
+    def _aggregateMonth(self, monthDir):
+        print("------------\nAggregating {}".format(monthDir))
+        files = self.dir.allJsonFiles(monthDir)
+        monthData = self._combine(files)
+        monthFile = str(monthDir) + ".json"
+        print(monthFile)
+        fs_util.write_all_events(monthFile, monthData)
+
+    def _combine(self, files):
+        result = map(lambda file: fs_util.read_all_events(file), files)
+        result = reduce(list.__add__, result)
+        result.sort(key = lambda x: x.get('timestamp'))
+        return result

--- a/static-gen/src/aggregator.py
+++ b/static-gen/src/aggregator.py
@@ -11,25 +11,28 @@ class Aggregator:
     def __init__(self, dir):
         self.dir = DataDir(dir)
 
-    def aggregateDates(self):
+    def rollUpDates(self):
         years = self.dir.getDateYears()
         print(years)
         for year in years:
-            self._aggregateYear(year)
+            self._rollUpYear(year)
+
+    def rollUpChannels(self):
+        pass
 
     # aggregattes a single year, which includes aggregating all
     # months that exist for that year
-    def _aggregateYear(self, yearDir):
+    def _rollUpYear(self, yearDir):
         monthDirs = self.dir.getSubdirs(yearDir)
-        [self._aggregateMonth(m) for m in monthDirs]
+        [self._rollUpMonth(m) for m in monthDirs]
         allMonthFiles = self.dir.allJsonFiles(yearDir)
-        print(yearDir)
-        print(allMonthFiles)
         yearData = self._combine(allMonthFiles)
         yearFile = str(yearDir) + '.json'
+        print("------------")
+        print(yearFile)
         fs_util.write_all_events(yearFile, yearData)
 
-    def _aggregateMonth(self, monthDir):
+    def _rollUpMonth(self, monthDir):
         print("------------\nAggregating {}".format(monthDir))
         files = self.dir.allJsonFiles(monthDir)
         monthData = self._combine(files)

--- a/static-gen/src/aggregator.py
+++ b/static-gen/src/aggregator.py
@@ -20,6 +20,16 @@ class Aggregator:
         channelDirs = self.dir.getChannelDirs()
         [self._rollUpChannel(ch) for ch in channelDirs]
 
+    def rollUpEvents(self):
+        eventDirs = self.dir.getEventDirs()
+        [self._rollUpEvent(ev) for ev in eventDirs]
+
+    def _rollUpEvent(self, eventDir):
+        print("Event: {}".format(eventDir))
+        dataDir = DataDir(eventDir)
+        yearDirs = dataDir.getDateYears()
+        [self._rollUpYear(y) for y in yearDirs]
+
     def _rollUpChannel(self, channelDir):
         print("Channel: {}".format(channelDir))
         chDir = DataDir(channelDir)

--- a/static-gen/src/data_dir.py
+++ b/static-gen/src/data_dir.py
@@ -18,6 +18,9 @@ class DataDir:
     def getChannelDirs(self):
         return self.getSubdirs(self.dir / 'channel')
 
+    def getEventDirs(self):
+        return self.getSubdirs(self.dir / 'events')
+
     def getSubdirs(self, subdirRoot):
         with os.scandir(subdirRoot) as it:
             all = list(it)

--- a/static-gen/src/data_dir.py
+++ b/static-gen/src/data_dir.py
@@ -15,6 +15,9 @@ class DataDir:
     def getDateYears(self):
         return self.getSubdirs(self.getDateDir())
 
+    def getChannelDirs(self):
+        return self.getSubdirs(self.dir / 'channel')
+
     def getSubdirs(self, subdirRoot):
         with os.scandir(subdirRoot) as it:
             all = list(it)

--- a/static-gen/src/data_dir.py
+++ b/static-gen/src/data_dir.py
@@ -1,0 +1,37 @@
+
+import pathlib
+import os
+
+# abstraction of the data output dir (pre aggregation)
+
+class DataDir:
+
+    def __init__(self, dir):
+        self.dir = pathlib.Path(dir)
+
+    def getDateDir(self):
+        return self.dir / 'date'
+
+    def getDateYears(self):
+        return self.getSubdirs(self.getDateDir())
+
+    def getSubdirs(self, subdirRoot):
+        with os.scandir(subdirRoot) as it:
+            all = list(it)
+            dirs = map(lambda x: x.name, filter(lambda x: x.is_dir(), all))
+            dirs = map(lambda x: self.dir / subdirRoot / x, dirs)
+            return list(dirs)
+
+    def dateYearMonthDir(self, root, year, month):
+        return self.yearMonthDir(self.getDateDir(), year, month)
+
+    def yearMonthDir(self, root, year, month):
+        return root / "{}/{:02d}".format(year, month)
+
+    # Not recursive, just top level
+    def allJsonFiles(self, subdir):
+        with os.scandir(self.dir / subdir) as it:
+            all = list(it)
+            files = filter(lambda x: x.is_file(), all)
+            json = filter(lambda x: x.name.endswith(".json"), files)
+            return list(map(lambda x: x.path, json))

--- a/static-gen/src/rollups.py
+++ b/static-gen/src/rollups.py
@@ -12,4 +12,4 @@ indir = sys.argv[1]
 print("Aggregating roll-ups in {}".format(indir))
 
 agg = Aggregator(indir)
-agg.aggregateDates()
+agg.rollUpDates()

--- a/static-gen/src/rollups.py
+++ b/static-gen/src/rollups.py
@@ -1,0 +1,15 @@
+
+import sys
+from aggregator import Aggregator
+
+# Recomputes aggregated roll-up data in the data dir
+
+if len(sys.argv) < 2:
+    print("Usage: {} <dir>".format(__file__))
+    sys.exit(-1)
+
+indir = sys.argv[1]
+print("Aggregating roll-ups in {}".format(indir))
+
+agg = Aggregator(indir)
+agg.aggregateDates()

--- a/static-gen/src/rollups.py
+++ b/static-gen/src/rollups.py
@@ -14,4 +14,6 @@ print("Aggregating roll-ups in {}".format(indir))
 agg = Aggregator(indir)
 agg.rollUpDates()
 agg.rollUpChannels()
+agg.rollUpEvents()
+
 print("All done.")

--- a/static-gen/src/rollups.py
+++ b/static-gen/src/rollups.py
@@ -13,3 +13,5 @@ print("Aggregating roll-ups in {}".format(indir))
 
 agg = Aggregator(indir)
 agg.rollUpDates()
+agg.rollUpChannels()
+print("All done.")


### PR DESCRIPTION
Right now it's primarily `<month>.json` and `<year>.json` spread around in various locations, such as `/date` and `/channel/{channel}/date` and `/events/{event}/date/`. Next step will be to run this as a step in the actions workflow.