### PR TITLE
Add event parser that now normalizes event names

### DIFF
--- a/static-gen/src/event_parser.py
+++ b/static-gen/src/event_parser.py
@@ -1,0 +1,21 @@
+import json
+import re
+
+def parseAll(lines):
+    return [parse(line) for line in lines]
+
+def parse(line):
+    # in s3, each line is its own json doc
+    event = json.loads(line)
+    event = fix_channel(event)
+    event = normalize_event_name(event)
+    return event
+
+def fix_channel(event):
+    result = dict(event)
+    result['channel'] = re.sub(r'(SIP).(.*)-.*', r'\1-\2', result['channel'])
+    return result
+
+def normalize_event_name(event):
+    event['event'] = re.sub(r'_', '-', event['event'])
+    return event

--- a/static-gen/src/spreader.py
+++ b/static-gen/src/spreader.py
@@ -1,24 +1,13 @@
-import json
-import re
 import event_spreader
 import date_spreader
 import channel_spreader
+import event_parser
 
 # Helps spread event data around on disk
 
-def fix_channels(events):
-    result = []
-    for e in events:
-        new = dict(e)
-        result.append(new)
-        new['channel'] = re.sub(r'(SIP).(.*)-.*', r'\1-\2', new['channel'])
-    return result
 
-def update_all(events):
-    # in s3, each line is its own json doc
-    events = map(lambda x: json.loads(x), events)
-
-    events = fix_channels(events)
+def update_all(lines):
+    events = event_parser.parseAll(lines)
     event_spreader.by_event(events)
     date_spreader.by_date(events)
     channel_spreader.by_channel(events)


### PR DESCRIPTION
We have some redundant event names like `robotron-what-are-the-robotrons-play` and `robotron-what_are_the_robotrons_play`. There are like 10 of them that are caused by underscore vs. hyphen difference. This just normalizes all underscores to hyphen. 

Because there may be future normalization we want to do, this also splits the handling into its own parser.