### PR TITLE
Add event list generator

### DIFF
--- a/static-gen/src/event_list.py
+++ b/static-gen/src/event_list.py
@@ -1,0 +1,14 @@
+import json
+from data_dir import DataDir
+
+# generates an event list
+
+def write_events(dir):
+    dir = DataDir(dir)
+    eventDirs = dir.getEventDirs()
+    outputFile = eventDirs[0].parent.parent / 'event-list.json'
+    print("Generating event list into {}".format(outputFile))
+    eventNames = list(map(lambda p: p.name, eventDirs))
+    with open(outputFile, 'w') as f:
+        json.dump(eventNames, f)
+    print("Event list written.")

--- a/static-gen/src/rollups.py
+++ b/static-gen/src/rollups.py
@@ -1,6 +1,7 @@
 
 import sys
 from aggregator import Aggregator
+import event_list
 
 # Recomputes aggregated roll-up data in the data dir
 
@@ -15,5 +16,7 @@ agg = Aggregator(indir)
 agg.rollUpDates()
 agg.rollUpChannels()
 agg.rollUpEvents()
+
+event_list.write_events(indir)
 
 print("All done.")


### PR DESCRIPTION
As part of the rollups, we will now generate an event list json file. This can then be used by the UI to dynamically populate a list of events for which we have data (no hard coding).