### PR TITLE
Filter out inactive phones by default (allow override)

### DIFF
--- a/web/src/graph.js
+++ b/web/src/graph.js
@@ -4,7 +4,7 @@ import * as dataLoader from './data-loader';
 import * as phoneList from './phone-list';
 import * as eventList from './event-list';
 import * as aggregation from './aggregation';
-import { stringToColor, uiShow, uiHide } from './ui';
+import { stringToColor, uiShow, uiHide, wantInactivePhones } from './ui';
 import Chart from 'chart.js/auto';
 
 let chart;
@@ -20,7 +20,14 @@ async function buildAndShow(){
   data = filterToSelectedPhones(data);
   data = filterToSelectedEvents(data);
   data = aggregation.aggregate(data);
+  data = filterAllZeroPhones(data);
   console.log(data);
+  if(Object.keys(data).length === 0){
+    uiHide('chartWrapper');
+    const totalsDiv = document.getElementById('totals');
+    totalsDiv.innerHTML = '<h2>no data (nothing)</h2>';
+    return;
+  }
   plot(data);
 }
 
@@ -123,6 +130,17 @@ function filterToSelectedPhones(data){
 function filterToSelectedEvents(data){
   const selectedEvents = eventList.getSelectedEvents();
   return data.filter(d => selectedEvents.includes(d.event));
+}
+
+function filterAllZeroPhones(data){
+  if(wantInactivePhones()) return data;
+  const pairs = Object.entries(data);
+  const filtered = pairs.filter(([phone,dateToCount]) => {
+    const counts = Object.values(dateToCount);
+    const sum = counts.reduce((prev,cur) => prev + cur);
+    return sum > 0;
+  });
+  return Object.fromEntries(filtered);
 }
 
 export {

--- a/web/src/ui.js
+++ b/web/src/ui.js
@@ -4,7 +4,6 @@ import * as graph from './graph';
 
 function init(){
   document.getElementById('allphones').onclick = () => {
-    console.log(phoneList);
     phoneList.selectAll();
   }
   document.getElementById('graphit').onclick = () => {
@@ -15,6 +14,9 @@ function init(){
     graph.buildAndShow();
   });
   document.getElementById('aggregate').addEventListener('change', e => {
+    graph.buildAndShow();
+  });
+  document.getElementById('showinactive').addEventListener('change', e => {
     graph.buildAndShow();
   });
 }
@@ -43,9 +45,16 @@ function uiHide(elemId){
   elem.classList.add('visually-hidden');
 }
 
+// Returns true if we want to graph data for phones whose content is all zeroes
+// for the given range
+function wantInactivePhones(){
+  return document.getElementById('showinactive').checked;
+}
+
 export {
   init,
   stringToColor,
   uiShow,
   uiHide,
+  wantInactivePhones
 };

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -67,7 +67,21 @@
       </nav>
       <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
         <h1 class="mt-3">FUTEL network usage</h1>
-        <button id='graphit' type="button" class="btn btn-primary my-2">graph it</button>
+        <div class="container-fluid">
+          <div class="row align-items-center">
+            <div class="col-1">
+              <button id='graphit' type="button" class="btn btn-primary my-2">graph it</button>
+            </div>
+            <div class="col-11">
+              <div id='showinactive-wrapper' class="form-check">
+                <input class="form-check-input" type="checkbox" value="" id="showinactive">
+                <label class="form-check-label" for="flexCheckDefault">
+                  show inactive
+                </label>
+              </div>
+            </div>
+          </div>
+        </div>
         <div id="chartWrapper">
           <canvas id="chart"></canvas>
         </div>


### PR DESCRIPTION
Resolves #7

By default, inactive phones (those with zeroes for all buckets in a given range) are not shown. It just makes the UI quite a bit cleaner. This can be overridden by ticking the "show inactive" checkbox.
The state is not maintained.