### PR TITLE
Relative dates

### DIFF
--- a/web/src/aggregation.js
+++ b/web/src/aggregation.js
@@ -2,9 +2,7 @@
 
 const dates = require('./dates');
 import * as phoneList from './phone-list';
-
-const MS_PER_DAY = 1000 * 60 * 60 * 24;
-const pad2 = x => `${x}`.padStart(2, '0');
+import { pad2, MS_PER_DAY } from './util';
 
 const HOURLY = {
   next: d => new Date(d.getTime() +  1000 * 60 * 60),
@@ -17,7 +15,7 @@ const HOURLY = {
 };
 const DAILY = {
   next: d => addDay(d),
-  bucket: d => `${d.getUTCFullYear()}-${pad2(d.getUTCMonth()+1)}-${pad2(d.getUTCDate())}`
+  bucket: d => dates.formatUTC(d)
 }
 const MONTHLY = {
   next: d => {
@@ -41,7 +39,7 @@ const WEEKLY = {
     while(d.getUTCDay() != 0){
       d = subtractDay(d);
     }
-    return `${d.getUTCFullYear()}-${pad2(d.getUTCMonth()+1)}-${pad2(d.getUTCDate())}`
+    return dates.formatUTC(d);
   }
 }
 const TOTAL = {

--- a/web/src/dates.js
+++ b/web/src/dates.js
@@ -1,6 +1,7 @@
 'use strict';
 import Litepicker from 'litepicker';
 const graph = require('./graph');
+import { pad2 } from './util';
 
 let picker;
 let selectedCb;
@@ -56,6 +57,10 @@ function haveDateRange(){
          new Date(start) <= new Date(end);
 }
 
+function formatUTC(d){
+  return `${d.getUTCFullYear()}-${pad2(d.getUTCMonth()+1)}-${pad2(d.getUTCDate())}`;
+}
+
 export {
   init,
   getStartDate,
@@ -63,5 +68,6 @@ export {
   setStartDate,
   setEndDate,
   setSelectedCb,
-  haveDateRange
+  haveDateRange,
+  formatUTC
 };

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -1,10 +1,10 @@
 'use strict';
-const d = require('./data-loader');
 const dates = require('./dates');
 const phoneList = require('./phone-list');
 const eventList = require('./event-list');
 const ui = require('./ui');
 const urlFoo = require('./url-foo');
+const relDates = require('./reldates');
 
 console.log('futel usage start : index.js')
 
@@ -14,6 +14,7 @@ async function initAll(){
   await eventList.init();
   ui.init();
   urlFoo.init();
+  relDates.init();
 }
 
 initAll();

--- a/web/src/reldates.js
+++ b/web/src/reldates.js
@@ -48,8 +48,12 @@ function computeStart(end, num, suffix){
     case 'w': return new Date(end.getTime() - (num*MS_PER_WEEK));
     case 'm':
       const result = new Date(end.getTime());
-      result.setMonth(end.getMonth()-num); // oh javascript, wow
+      result.setUTCMonth(end.getUTCMonth()-num); // oh javascript, wow
       return result;
+    case 'y':
+      const yresult = new Date(end.getTime());
+      yresult.setUTCFullYear(end.getUTCFullYear()-num);
+      return yresult;
   }
 }
 

--- a/web/src/reldates.js
+++ b/web/src/reldates.js
@@ -1,0 +1,56 @@
+'use strict';
+const dates = require('./dates');
+import {MS_PER_HOUR, MS_PER_DAY, MS_PER_WEEK } from './util';
+const graph = require('./graph');
+
+let timer;
+
+function init(){
+  const input = document.getElementById('date-rel');
+  input.addEventListener('input', inputChanged);
+}
+
+function inputChanged(e){
+  if(timer){
+    clearTimeout(timer);
+    timer = null;
+  }
+  timer = setTimeout(handleNewValue, 200);
+}
+
+function handleNewValue(){
+  const value = document.getElementById('date-rel').value.trim().toLowerCase();
+  const err = document.getElementById('reldate-err');
+  err.innerText = '';
+  if(!validate(value)){
+    err.innerText = 'invalid/unrecognized format';
+    return;
+  }
+  const [x, num, suffix] = value.match(/^-(\d+)\s*([hdwmy])$/);
+  const end = new Date();
+  const start = computeStart(end, parseInt(num), suffix);
+  console.log(`relative: ${dates.formatUTC(start)} -> ${dates.formatUTC(end)}`)
+  dates.setStartDate(dates.formatUTC(start));
+  dates.setEndDate(dates.formatUTC(end));
+  graph.buildAndShow();
+}
+
+function computeStart(end, num, suffix){
+  switch(suffix){
+    case 'h': return new Date(end.getTime() - (num*MS_PER_HOUR));
+    case 'd': return new Date(end.getTime() - (num*MS_PER_DAY));
+    case 'w': return new Date(end.getTime() - (num*MS_PER_WEEK));
+    case 'm':
+      const result = new Date(end.getTime());
+      result.setMonth(end.getMonth()-num); // oh javascript, wow
+      return result;
+  }
+}
+
+function validate(value){
+  return value.match(/^-\d+\s*[hdwmy]$/);
+}
+
+export {
+  init
+}

--- a/web/src/reldates.js
+++ b/web/src/reldates.js
@@ -1,12 +1,13 @@
 'use strict';
 const dates = require('./dates');
 import {MS_PER_HOUR, MS_PER_DAY, MS_PER_WEEK } from './util';
+const urlFoo = require('./url-foo');
 const graph = require('./graph');
 
 let timer;
 
 function init(){
-  const input = document.getElementById('date-rel');
+  const input = getInput();
   input.addEventListener('input', inputChanged);
 }
 
@@ -18,8 +19,12 @@ function inputChanged(e){
   timer = setTimeout(handleNewValue, 200);
 }
 
+function getInput(){
+  return document.getElementById('date-rel');
+}
+
 function handleNewValue(){
-  const value = document.getElementById('date-rel').value.trim().toLowerCase();
+  const value = getInput().value.trim().toLowerCase();
   const err = document.getElementById('reldate-err');
   err.innerText = '';
   if(!validate(value)){
@@ -32,6 +37,7 @@ function handleNewValue(){
   console.log(`relative: ${dates.formatUTC(start)} -> ${dates.formatUTC(end)}`)
   dates.setStartDate(dates.formatUTC(start));
   dates.setEndDate(dates.formatUTC(end));
+  urlFoo.updateReldate(value);
   graph.buildAndShow();
 }
 
@@ -51,6 +57,12 @@ function validate(value){
   return value.match(/^-\d+\s*[hdwmy]$/);
 }
 
+function setReldateExpr(expr){
+  getInput().value = expr;
+  handleNewValue();
+}
+
 export {
-  init
+  init,
+  setReldateExpr
 }

--- a/web/src/url-foo.js
+++ b/web/src/url-foo.js
@@ -62,6 +62,7 @@ function updateDates(){
   const endDate = document.getElementById('date-end');
   setOrDelete('start', startDate.value);
   setOrDelete('end', endDate.value);
+  setOrDelete('r');
 }
 
 function setOrDelete(name, value){

--- a/web/src/url-foo.js
+++ b/web/src/url-foo.js
@@ -4,6 +4,7 @@ const dates = require('./dates');
 const phoneList = require('./phone-list');
 const eventList = require('./event-list');
 const graph = require('./graph');
+const reldates = require('./reldates');
 
 function init(){
   const phoneSel = document.getElementById('phone-list');
@@ -47,6 +48,10 @@ function bootstrapUrl(){
       }
     });
   }
+  const r = url.searchParams.get('r');
+  if(r){
+    return reldates.setReldateExpr(r);
+  }
   if(url.searchParams.toString()){
       graph.buildAndShow();
   }
@@ -84,6 +89,12 @@ function updateAggregation(event){
   });
 }
 
+function updateReldate(expr){
+  setOrDelete('start');
+  setOrDelete('end');
+  setOrDelete('r', expr);
+}
+
 function updateEventSelection(event){
   const events = eventList.getSelectedEvents();
   console.log(events);
@@ -91,5 +102,6 @@ function updateEventSelection(event){
 }
 
 export {
-  init
+  init,
+  updateReldate
 }

--- a/web/src/util.js
+++ b/web/src/util.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const MS_PER_HOUR = 1000 * 60 * 60;
+const MS_PER_DAY = MS_PER_HOUR * 24;
+const MS_PER_WEEK = MS_PER_DAY * 7;
+
+const pad2 = x => `${x}`.padStart(2, '0');
+
+export {
+  pad2,
+  MS_PER_HOUR,
+  MS_PER_WEEK,
+  MS_PER_DAY
+}

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -15,12 +15,36 @@
         <img src="futel_logo_black.png" alt="futel" class="my-2" width=120px/>
 
         <ul class="nav flex-column">
-          <li class="nav-item fw-bold">
+          <ul class="nav nav-tabs" id="myTab" role="tablist">
+            <li class="nav-item" role="presentation">
+              <button class="nav-link active" id="relative-tab" data-bs-toggle="tab" data-bs-target="#relative" type="button" role="tab" aria-controls="relative" aria-selected="true">Relative</button>
+            </li>
+            <li class="nav-item" role="presentation">
+              <button class="nav-link" id="absolute-tab" data-bs-toggle="tab" data-bs-target="#absolute" type="button" role="tab" aria-controls="absolute" aria-selected="false">Absolute</button>
+            </li>
+          </ul>
+          <div class="tab-content" id="myTabContent">
+            <div class="tab-pane fade show active" id="relative" role="tabpanel" aria-labelledby="relative-tab">
+              Enter relative date:
+              <br/><input type="text" id="date-rel" class="p-2 my-2">
+              <br/><i>(eg. -1w or -30d, relative to now)</i>
+              <span id='reldate-err' class='text-danger'></span>
+            </div>
+            <div class="tab-pane fade" id="absolute" role="tabpanel" aria-labelledby="absolute-tab">
+              <span class="fw-bold">Start: </span>
+              <br/><input type="text" id="date-start" class="dateinput">
+              <span class="fw-bold">End: </span>
+              <br/><input type="text" id="date-end" class="dateinput">
+            </div>
+          </div>
+
+
+          <!-- <li class="nav-item fw-bold">
             Start: <br/><input type="text" id="date-start" class="dateinput">
           </li>
           <li class="nav-item fw-bold">
             End: <br/><input type="text" id="date-end" class="dateinput">
-          </li>
+          </li> -->
           <li class="nav-item">
             <span class="fw-bold">Phones:</span>
             <button id='allphones' type="button" class="btn btn-primary my-2">all</button>

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -38,13 +38,6 @@
             </div>
           </div>
 
-
-          <!-- <li class="nav-item fw-bold">
-            Start: <br/><input type="text" id="date-start" class="dateinput">
-          </li>
-          <li class="nav-item fw-bold">
-            End: <br/><input type="text" id="date-end" class="dateinput">
-          </li> -->
           <li class="nav-item">
             <span class="fw-bold">Phones:</span>
             <button id='allphones' type="button" class="btn btn-primary my-2">all</button>


### PR DESCRIPTION
resolves #18 

This adds a little tabbed widget which now defaults to "relative dates". 
The other tab allows picking the absolute dates like before.
The absolute dates are altered when the user edits the relative date field, and the absolute dates are still what is used when the graph is created.

Should play nicely with the url foo as well -- when the relative expression is edited the absolute dates get removed from the url, and when the absolute dates are updated or picked with the picker the relative bits get removed.