### PR TITLE
Aggregate channels

### DIFF
--- a/.github/workflows/generate-static-data.yml
+++ b/.github/workflows/generate-static-data.yml
@@ -35,6 +35,8 @@ jobs:
       run: rsync -avv static-gen/build/ gh-pages/data/ && rm -rf static-gen/build
     - name: generate rollups
       run: python static-gen/src/rollups.py gh-pages/data/
+    - name: build aggregations rollups
+      run: python static-gen/src/aggregate.py gh-pages/data/
     - name: debug peek in the data directory
       run: ls -l gh-pages && ls -l gh-pages/data
     - name: commit updated data

--- a/static-gen/src/aggregate.py
+++ b/static-gen/src/aggregate.py
@@ -1,0 +1,17 @@
+
+import sys
+from channel_year_agg import ChannelYearAggregator
+
+# Recomputes aggregated roll-up data in the data dir
+
+if len(sys.argv) < 2:
+    print("Usage: {} <dir>".format(__file__))
+    sys.exit(-1)
+
+indir = sys.argv[1]
+print("Performing aggregation in {}".format(indir))
+
+agg = ChannelYearAggregator(indir)
+agg.create()
+
+print("All done.")

--- a/static-gen/src/channel_year_agg.py
+++ b/static-gen/src/channel_year_agg.py
@@ -1,0 +1,81 @@
+import pathlib
+import json
+import re
+from data_dir import DataDir
+import fs_util
+
+EPOCH = '1970-01-01T00:00:00+00:00'
+
+# Aggregates and creates summary files for every year of every channel
+class ChannelYearAggregator:
+
+    def __init__(self, dir):
+        self.dir = DataDir(dir)
+
+    def create(self):
+        channelDirs = self.dir.getChannelDirs()
+        for channelDir in channelDirs:
+            self.createChannel(DataDir(channelDir))
+
+    def createChannel(self, channelDir):
+        print(channelDir.dir)
+        jsonFiles = channelDir.allJsonFiles('date')
+        for jf in jsonFiles:
+            jf = pathlib.Path(jf)
+            if re.match('^\d\d\d\d.json$', jf.name):
+                self.createYear(channelDir, jf)
+
+
+    def createYear(self, channelDir,  yearFile):
+        year = re.match('^(\d\d\d\d).json$', yearFile.name)[1]
+        print("\nAggregating {} from {}".format(year, yearFile.resolve()))
+        events = fs_util.read_all_events(yearFile)
+        byDate = self._byDate(events)
+        totals = self._totals(events)
+        latest = self._latestByEvent(events)
+        completeLatest = self._completeLatest(latest)
+        agg = { 'by_day': byDate, 'totals': totals, 'latest': latest,
+                'complete_latest': completeLatest}
+        filename = channelDir.dir / 'date' / "{}_agg.json".format(year)
+        with open(filename, 'w') as f:
+            json.dump(agg, f)
+
+    def _byDate(self, events):
+        agg = dict()
+        for event in events:
+            date = re.sub(r'T.*', '', event['timestamp'])
+            if date not in agg:
+                agg[date] = dict()
+            eventName = event['event']
+            if eventName not in agg[date]:
+                agg[date][eventName] = 0
+            agg[date][eventName] += 1
+        return agg
+
+    def _totals(self, events):
+        agg = dict()
+        for event in events:
+            eventName = event['event']
+            if eventName not in agg:
+                agg[eventName] = 0
+            agg[eventName] += 1
+        return agg
+
+    def _latestByEvent(self, events):
+        agg = dict()
+        for event in events:
+            timestamp = event['timestamp']
+            eventName = event['event']
+            if eventName not in agg:
+                agg[eventName] = EPOCH
+            if timestamp > agg[eventName]:
+                agg[eventName] = timestamp
+        return agg
+
+    def _completeLatest(self, latest):
+        completeLatest = {'event': 'bs', 'timestamp': EPOCH}
+        for event,timestamp in latest.items():
+            if timestamp > completeLatest['timestamp']:
+                completeLatest['event'] = event
+                completeLatest['timestamp'] = timestamp
+        return completeLatest

--- a/static-gen/src/roll_up_tool.py
+++ b/static-gen/src/roll_up_tool.py
@@ -4,9 +4,9 @@ import fs_util
 import json
 from functools import reduce
 
-# does all the aggregation
+# does all the roll ups (data combining)
 
-class Aggregator:
+class RollupTool:
 
     def __init__(self, dir):
         self.dir = DataDir(dir)
@@ -36,7 +36,7 @@ class Aggregator:
         yearDirs = chDir.getDateYears()
         [self._rollUpYear(y) for y in yearDirs]
 
-    # aggregattes a single year, which includes aggregating all
+    # rolls up (combines) a single year, which includes combining all
     # months that exist for that year
     def _rollUpYear(self, yearDir):
         monthDirs = self.dir.getSubdirs(yearDir)

--- a/static-gen/src/rollups.py
+++ b/static-gen/src/rollups.py
@@ -1,6 +1,6 @@
 
 import sys
-from aggregator import Aggregator
+from roll_up_tool import RollUpTool
 import event_list
 
 # Recomputes aggregated roll-up data in the data dir
@@ -10,12 +10,12 @@ if len(sys.argv) < 2:
     sys.exit(-1)
 
 indir = sys.argv[1]
-print("Aggregating roll-ups in {}".format(indir))
+print("Creating roll-ups in {}".format(indir))
 
-agg = Aggregator(indir)
-agg.rollUpDates()
-agg.rollUpChannels()
-agg.rollUpEvents()
+roll = RollUpTool(indir)
+roll.rollUpDates()
+roll.rollUpChannels()
+roll.rollUpEvents()
 
 event_list.write_events(indir)
 


### PR DESCRIPTION
Relates to #15
First thing, rename the rollups to rollups so as to not confuse actually aggregation.
Then, this adds a per-channel per-year aggregation file output that we create as part of the data generation GHA. In this file, we have:
* per-day totals of for each seen event
* year-to-date totals for each seen event
* list of most recent message of each type
* very most recent event name and timestamp