### PR TITLE
Limit spreading

### DIFF
--- a/static-gen/src/channel_year_agg.py
+++ b/static-gen/src/channel_year_agg.py
@@ -23,23 +23,24 @@ class ChannelYearAggregator:
         for jf in jsonFiles:
             jf = pathlib.Path(jf)
             if re.match('^\d\d\d\d.json$', jf.name):
-                self.createYear(channelDir, jf)
+                print("Skipping year {} aggregation (too big!)".format(jf.name))
+                # self.createYear(channelDir, jf)
 
 
-    def createYear(self, channelDir,  yearFile):
-        year = re.match('^(\d\d\d\d).json$', yearFile.name)[1]
-        print("Aggregating {} from {}".format(year, yearFile.resolve()))
-        events = fs_util.read_all_events(yearFile)
-        byDate = self._byDate(events)
-        totals = self._totals(events)
-        recent = self._recent(events)
-        mostRecent = self._mostRecent(recent)
-        agg = { 'by_day': byDate, 'totals': totals, 'recent': recent,
-                'most_recent': mostRecent}
-        filename = channelDir.dir / 'date' / "{}_agg.json".format(year)
-        with open(filename, 'w') as f:
-            json.dump(agg, f)
-        print("  wrote {}".format(filename))
+    # def createYear(self, channelDir,  yearFile):
+    #     year = re.match('^(\d\d\d\d).json$', yearFile.name)[1]
+    #     print("Aggregating {} from {}".format(year, yearFile.resolve()))
+    #     events = fs_util.read_all_events(yearFile)
+    #     byDate = self._byDate(events)
+    #     totals = self._totals(events)
+    #     recent = self._recent(events)
+    #     mostRecent = self._mostRecent(recent)
+    #     agg = { 'by_day': byDate, 'totals': totals, 'recent': recent,
+    #             'most_recent': mostRecent}
+    #     filename = channelDir.dir / 'date' / "{}_agg.json".format(year)
+    #     with open(filename, 'w') as f:
+    #         json.dump(agg, f)
+    #     print("  wrote {}".format(filename))
 
     def _byDate(self, events):
         agg = dict()

--- a/static-gen/src/roll_up_tool.py
+++ b/static-gen/src/roll_up_tool.py
@@ -14,7 +14,9 @@ class RollUpTool:
     def rollUpDates(self):
         years = self.dir.getDateYears()
         print(years)
-        [self._rollUpYear(y) for y in years]
+        # 2022-11-13 disabling year rollup (too huge)
+        print('Skipping year rollups because they are too huge now.')
+        # [self._rollUpYear(y) for y in years]
 
     def rollUpChannels(self):
         channelDirs = self.dir.getChannelDirs()

--- a/static-gen/src/spreader.py
+++ b/static-gen/src/spreader.py
@@ -8,6 +8,6 @@ import event_parser
 
 def update_all(lines):
     events = event_parser.parseAll(lines)
-    event_spreader.by_event(events)
     date_spreader.by_date(events)
-    channel_spreader.by_channel(events)
+    # event_spreader.by_event(events)
+    # channel_spreader.by_channel(events)


### PR DESCRIPTION
Actions are failing due to year rollups (for all events and for single events, like the vpn contact status) being too huge. They're not currently used anyway