### PR TITLE
Aggregate unique event list based on last 3 days data

### DIFF
--- a/.github/workflows/generate-static-data.yml
+++ b/.github/workflows/generate-static-data.yml
@@ -37,6 +37,8 @@ jobs:
       run: python static-gen/src/rollups.py gh-pages/data/
     - name: build aggregations rollups
       run: python static-gen/src/aggregate.py gh-pages/data/
+    - name: update unique event list
+      run: python static-gen/src/event_list.py gh-pages/data/
     - name: debug peek in the data directory
       run: ls -l gh-pages && ls -l gh-pages/data
     - name: commit updated data

--- a/static-gen/src/data_dir.py
+++ b/static-gen/src/data_dir.py
@@ -27,7 +27,7 @@ class DataDir:
             dirs = map(lambda x: self.dir / subdirRoot / x, dirs)
             return list(dirs)
 
-    def dateYearMonthDir(self, root, year, month):
+    def dateYearMonthDir(self, year, month):
         return self.yearMonthDir(self.getDateDir(), year, month)
 
     def yearMonthDir(self, root, year, month):

--- a/static-gen/src/event_list.py
+++ b/static-gen/src/event_list.py
@@ -1,14 +1,50 @@
+import sys
 import json
+import datetime
+from datetime import date
 from data_dir import DataDir
 
-# generates an event list
+# generates a set of unique events
 
-def write_events(dir):
-    dir = DataDir(dir)
-    eventDirs = dir.getEventDirs()
-    outputFile = eventDirs[0].parent.parent / 'event-list.json'
-    print("Generating event list into {}".format(outputFile))
-    eventNames = list(map(lambda p: p.name, eventDirs))
-    with open(outputFile, 'w') as f:
-        json.dump(eventNames, f)
-    print("Event list written.")
+def read_events(dir):
+    file = dir / 'event-list.json'
+    with open(file, 'r') as file:
+        return json.load(file)
+
+def write_events(dir, events):
+    file = dir / 'event-list.json'
+    with open(file, "w") as outfile:
+        outfile.write(json.dumps(sorted(events)))
+
+def get_event_names_for_date(dir, targetDate):
+    year_month_dir = dir.dateYearMonthDir(targetDate.year, targetDate.month)
+    file = year_month_dir / targetDate.strftime("%Y%m%d.json")
+    with open(file, 'r') as file:
+        data = json.load(file)
+        return set(map(lambda event: event['event'], data))
+
+# Read most 3 days of events
+def read_past_events(dir):
+    result = set()
+    dates = map(lambda i: date.today() - datetime.timedelta(i), range(0,3))
+    for d in dates:
+        events = get_event_names_for_date(dir, d)
+        result.update(events)
+    return result
+
+if __name__ == "__main__":
+
+    if len(sys.argv) < 2:
+        print("Usage: {} <dir>".format(__file__))
+        sys.exit(-1)
+
+    indir = sys.argv[1]
+    dir = DataDir(indir)
+
+    events = read_events(dir.dir)
+    print(json.dumps(sorted(events)))
+    latest_events = read_past_events(dir)
+
+    all = set(events)
+    all.update(latest_events)
+    write_events(dir.dir, list(all))

--- a/static-gen/src/rollups.py
+++ b/static-gen/src/rollups.py
@@ -1,7 +1,6 @@
 
 import sys
 from roll_up_tool import RollUpTool
-import event_list
 
 # Recomputes aggregated roll-up data in the data dir
 
@@ -14,9 +13,9 @@ print("Creating roll-ups in {}".format(indir))
 
 roll = RollUpTool(indir)
 roll.rollUpDates()
+
+# Skip rolling up channels and events because we only use date now really
 # roll.rollUpChannels()
 # roll.rollUpEvents()
-
-event_list.write_events(indir)
 
 print("All done.")


### PR DESCRIPTION
Previously, we would use the aggregated event data to build the list of unique event names. Now that we no longer roll up the data by events, that doesn't work. We deleted those data when we squashed `gh-pages` branch history.

So now we just look at the last 3 days, make a set of the event names, and add it to the existing set.

This runs as its own build pipeline step, rather than being tagged on to the end of rollups as before.